### PR TITLE
use cron schedule for exports creation/retention and session cleanup

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,23 +9,23 @@ import (
 )
 
 type Config struct {
-	ApiPollers           int           `yaml:"apiPollers"`
-	BackupPath           string        `yaml:"backupPath"`
-	ExportWorkers        int           `yaml:"exportWorkers"`
-	DevicePollerInterval time.Duration `yaml:"devicePollerInterval"`
-	DeviceExportInterval time.Duration `yaml:"deviceExportInterval"`
-	DbPath               string        `yaml:"dbPath"`
-	DbLogLevel           string        `yaml:"dbLogLevel"`
-	EncryptionKey        string        `yaml:"encryptionKey"`
-	LogLevel             string        `yaml:"logLevel"`
-	S3Bucket             string        `yaml:"s3Bucket"`
-	S3BucketPath         string        `yaml:"s3BucketPath"`
-	S3Endpoint           string        `yaml:"s3Endpoint"`
-	S3Region             string        `yaml:"s3Region"`
-	S3StorageClass       string        `yaml:"s3StorageClass"`
-	S3AccessKey          string        `yaml:"s3AccessKey"`
-	S3SecretAccessKey    string        `yaml:"s3SecretAccessKey"`
-	S3OpsRetries         int           `yaml:"s3OpsRetries"`
+	ApiPollers               int           `yaml:"apiPollers"`
+	BackupPath               string        `yaml:"backupPath"`
+	ExportWorkers            int           `yaml:"exportWorkers"`
+	DevicePollerInterval     time.Duration `yaml:"devicePollerInterval"`
+	deviceExportCronSchedule string        `yaml:"deviceExportCronSchedule"`
+	DbPath                   string        `yaml:"dbPath"`
+	DbLogLevel               string        `yaml:"dbLogLevel"`
+	EncryptionKey            string        `yaml:"encryptionKey"`
+	LogLevel                 string        `yaml:"logLevel"`
+	S3Bucket                 string        `yaml:"s3Bucket"`
+	S3BucketPath             string        `yaml:"s3BucketPath"`
+	S3Endpoint               string        `yaml:"s3Endpoint"`
+	S3Region                 string        `yaml:"s3Region"`
+	S3StorageClass           string        `yaml:"s3StorageClass"`
+	S3AccessKey              string        `yaml:"s3AccessKey"`
+	S3SecretAccessKey        string        `yaml:"s3SecretAccessKey"`
+	S3OpsRetries             int           `yaml:"s3OpsRetries"`
 }
 
 func configProcessError(err error) {
@@ -41,8 +41,8 @@ func (cfg *Config) setDefaults() {
 	if cfg.DevicePollerInterval == 0 {
 		cfg.DevicePollerInterval = time.Millisecond * 1000 * 300
 	}
-	if cfg.DeviceExportInterval == 0 {
-		cfg.DeviceExportInterval = time.Hour * 1
+	if cfg.deviceExportCronSchedule == "" {
+		cfg.deviceExportCronSchedule = "0 * * * *"
 	}
 	if cfg.DbPath == "" {
 		cfg.DbPath = "database/mikromanager.db"

--- a/config.yml
+++ b/config.yml
@@ -23,11 +23,9 @@ apiPollers: 2
 # valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
 # devicePollerInterval: 30s
 
-# deviceExportInterval defines how often devices config should be exported/backed up,
-# the time is between finish of a previous run and start of the new one
-# defaults to 1 hour if ommited
-# valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-# deviceExportInterval: 1h
+# deviceExportCronSchedule defines the cron schedule for creating device configuration exports
+# defaults to `0 * * * *` if ommited
+# deviceExportCronSchedule: 0 * * * *
 
 # full or relative path to the database, defaults to `database/mikromanager.db` if ommited
 dbPath: database/mikromanager.db

--- a/main.go
+++ b/main.go
@@ -137,9 +137,9 @@ func main() {
 	if pollerErr != nil {
 		logger.Error("poller", zap.Any("Job", pollerJob), zap.Any("error", pollerErr))
 	}
-	logger.Info("deviceExportInterval", zap.Duration("interval", config.DeviceExportInterval))
+	logger.Info("deviceExportCronSchedule", zap.String("cron schedule", config.deviceExportCronSchedule))
 	exportJob, exportErr := scheduler.NewJob(
-		gocron.DurationJob(config.DeviceExportInterval),
+		gocron.CronJob(config.deviceExportCronSchedule, false),
 		gocron.NewTask(backupScheduler, config, &db, exportCH),
 	)
 	if exportErr != nil {
@@ -147,7 +147,7 @@ func main() {
 	}
 	logger.Info("export retention job interval is 24 hours")
 	exportRetentionJob, exportRetentionErr := scheduler.NewJob(
-		gocron.DurationJob(24*time.Hour),
+		gocron.CronJob("0 * * * *", false),
 		gocron.NewTask(rotateExports, &db),
 	)
 	if exportRetentionErr != nil {
@@ -155,7 +155,7 @@ func main() {
 	}
 	logger.Info("session cleanup job interval is 24 hours")
 	sessionCleanupJob, sessionCleanupErr := scheduler.NewJob(
-		gocron.DurationJob(24*time.Hour),
+		gocron.CronJob("0 * * * *", false),
 		gocron.NewTask(cleanupSessions, &db),
 	)
 	if sessionCleanupErr != nil {


### PR DESCRIPTION
this gives better control over the jobs - the jobs are starting not `N` after that app startup but at the certain cron schedule, giving more consistency